### PR TITLE
Fix extraction of Windows absolute paths

### DIFF
--- a/aff4.py
+++ b/aff4.py
@@ -343,11 +343,10 @@ def extractAllFromVolume(container_urn, volume, destFolder):
         imageUrn = utils.SmartUnicode(imageUrn)
 
         pathName = next(resolver.QuerySubjectPredicate(volume.urn, imageUrn, lexicon.standard11.pathName)).value
-        if pathName.startswith("/"):
-            pathName = "." + pathName
         with resolver.AFF4FactoryOpen(imageUrn) as srcStream:
             if destFolder != "-":
-                destFile = os.path.join(destFolder, pathName)
+                drive, pathName = os.path.splitdrive(pathName) # Windows drive letters
+                destFile = os.path.join(destFolder, drive[:-1], pathName.strip("/\\"))
                 if not os.path.exists(os.path.dirname(destFile)):
                     try:
                         os.makedirs(os.path.dirname(destFile))
@@ -370,6 +369,7 @@ def extractAllFromVolume(container_urn, volume, destFolder):
 
             else:
                 shutil.copyfileobj(srcStream, sys.stdout)
+
 def extractAll(container_name, destFolder, password):
     container_urn = rdfvalue.URN.FromFileName(container_name)
     urn = None
@@ -398,7 +398,8 @@ def extractFromVolume(container_urn, volume, imageURNs, destFolder):
                 pathName = escaping.arnPathFragment_from_path(pathName.value)
                 while pathName.startswith("/"):
                     pathName = pathName[1:]
-                destFile = os.path.join(destFolder, pathName)
+                drive, pathName = os.path.splitdrive(pathName) # Windows drive letters
+                destFile = os.path.join(destFolder, drive[:-1], pathName.strip("/\\"))
                 if not os.path.exists(os.path.dirname(destFile)):
                     try:
                         os.makedirs(os.path.dirname(destFile))


### PR DESCRIPTION
os.path.join() discards earlier arguments if a part contains an absolute path, i.e. starts with slash(es) or a drive letter. As a result, in extractFromVolume and extractAllFromVolume, destFolder is ignored if pathName is a Windows absolute path. This commit strips leading slashes and removes the colon if a drive letter is present in pathName.